### PR TITLE
feat: Implement `ProjectView` to display project fragments

### DIFF
--- a/src/components/hint.tsx
+++ b/src/components/hint.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import {
+    Tooltip,
+    TooltipTrigger,
+    TooltipContent,
+    TooltipProvider
+} from "@/components/ui/tooltip";
+
+interface HintProps {
+    children: React.ReactNode;
+    text: string;
+    side: "top" | "right" | "bottom" | "left";
+    align: "start" | "center" | "end";
+
+};
+
+export const Hint = ({ children, text, side = "top", align = "center" }: HintProps) => {
+    return (
+        <TooltipProvider>
+            <Tooltip>
+                <TooltipTrigger asChild>{children}</TooltipTrigger>
+                <TooltipContent side={side} align={align}>
+                    {text}
+                </TooltipContent>
+            </Tooltip>
+        </TooltipProvider>
+    )
+}
+

--- a/src/modules/projects/ui/components/fragment-web.tsx
+++ b/src/modules/projects/ui/components/fragment-web.tsx
@@ -1,0 +1,68 @@
+import { Fragment } from "@/generated/prisma";
+import { ExternalLinkIcon, RefreshCcwIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useState } from "react";
+import { Hint } from "@/components/hint";
+
+interface Props {
+    data: Fragment;
+}
+
+export const FragmentWeb = ({ data }: Props) => {
+
+    const [fragmentKey, setFragmentKey] = useState(0);
+    const [copied, setCopied] = useState(false);
+
+    const onRefresh = () => {
+        setFragmentKey((prev) => prev + 1);
+    }
+    const handleCopy = () => {
+        navigator.clipboard.writeText(data.sandboxUrl);
+        setCopied(true);
+        setTimeout(() => {
+            setCopied(false);
+        }, 2000);
+    }
+    return (
+        <div className="flex flex-col w-full h-full">
+            <div className="p-2 border-b bg-sidebar flex item-center gap-x-2 ">
+                <Hint text="Refresh" side="bottom" align="center">
+                    <Button size="sm" variant="outline" onClick={onRefresh}>
+                        <RefreshCcwIcon />
+                    </Button>
+
+                </Hint>
+
+                <Hint text="Copy URL" side="bottom" align="center">
+                    <Button size="sm" variant="outline" onClick={handleCopy}
+                        disabled={!data.sandboxUrl || copied}
+
+                        className="flex-1 justify-start text-start font-normal">
+                        <span className="truncate">{data.sandboxUrl}</span>
+                    </Button>
+                </Hint>
+
+                <Hint text="Open in a new tab" side="bottom" align="start">
+
+                    <Button
+                        size="sm"
+                        disabled={!data.sandboxUrl}
+                        variant="outline"
+                        onClick={() => {
+                            if (!data.sandboxUrl) return;
+                            window.open(data.sandboxUrl, "_blank");
+                        }}
+                    >
+                        <ExternalLinkIcon />
+                    </Button>
+                </Hint>
+
+            </div>
+            <iframe
+                key={fragmentKey}
+                sandbox="allow-forms allow-scripts allow-same-origin" loading="lazy" className="w-full h-full" src={data.sandboxUrl} />
+
+        </div>
+    )
+}
+

--- a/src/modules/projects/ui/views/project-view.tsx
+++ b/src/modules/projects/ui/views/project-view.tsx
@@ -10,6 +10,7 @@ import { MessagesContainer } from "../components/messages-container";
 import { Suspense, useState } from "react";
 import { Fragment } from "@/generated/prisma";
 import { ProjectHeader } from "../components/project-header";
+import { FragmentWeb } from "../components/fragment-web";
 
 interface Props {
     projectId: string;
@@ -41,9 +42,7 @@ export const ProjectView = ({ projectId }: Props) => {
                     defaultSize={65}
                     minSize={50}
                 >
-                    <Suspense fallback={<div>Loading Preview...</div>}>
-                        Preview
-                    </Suspense>
+                    {!!activeFragment && <FragmentWeb data={activeFragment} />}
                 </ResizablePanel>
 
             </ResizablePanelGroup>


### PR DESCRIPTION
feat: Implement `ProjectView` to display project fragments, includin`FragmentWeb` for interactive web content and a new `Hint` UI component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive web preview panel with action controls: refresh content, copy URL to clipboard with visual feedback, and open in new tab.
  * Integrated tooltip-enhanced interface elements for improved usability and clarity.
  * Fragment preview now displays seamlessly in project workspace with responsive layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->